### PR TITLE
UPDATE: Don't use double negation and and bitwise not in indexOf

### DIFF
--- a/class.js
+++ b/class.js
@@ -55,7 +55,7 @@ define( function() {
 		 * @return {Boolean}
 		 */
 		has: function( str ) {
-			return !!~( wrap( this.get() ) ).indexOf( wrap( str ) );
+			return ( wrap( this.get() ) ).indexOf( wrap( str ) ) > -1;
 		},
 
 		/**


### PR DESCRIPTION
The reasons for this are two-fold. It will make more sense to almost anyone reading the code (in my opinion using the bitwise not is just being intentionally clever). And it is slightly faster.

http://jsperf.com/indexof-not-not-tilde-vs-1
