### PR TITLE
Fix "main" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
       "name": "Pieter Vanderwerff"
     }
   ],
-  "main": [
-    "class.js"
-  ],
+  "main": "class.js",
   "devDependencies": {
     "buster": "~0.6",
     "buster-amd": "git://github.com/busterjs/buster-amd.git",


### PR DESCRIPTION
Node itself seems to tolerate this parameter being an array, but node-browserify chokes on it.
